### PR TITLE
Fix items.info error from vendors.

### DIFF
--- a/methods/items.js
+++ b/methods/items.js
@@ -22,11 +22,11 @@ exports.findNearest = function(req, pc) {
  * Fetch details on a single or list of item(s). Include extra info if authed.
  */
 exports.info = function(req, pc) {
-	if (!req.query.item_classes) {
+	if (!req.query.item_classes && !req.body.item_classes) {
 		throw new Error('item_class_required');
 	}
 	var body = {};
-	var items = req.query.item_classes.split(',');
+	var items = req.query.item_classes ? req.query.item_classes.split(',') : req.body.item_classes.split(',');
 	for (var i = 0; i < items.length; i++) {
 		var item_class = items[i];
 		if (gsData.items[item_class]) {


### PR DESCRIPTION
If the client wants to know info on more than 30 items, the list is in post.

see com.tinyspeck.engine.api.ApiCall.as:87
