### PR TITLE
add preset config template for the Vagrant setup

### DIFF
--- a/config/local.json.SAMPLE_VAGRANT
+++ b/config/local.json.SAMPLE_VAGRANT
@@ -1,0 +1,7 @@
+{
+	"port": 9001,
+	"rpcHost": "192.168.23.23",
+	"rpcPort": 6001,
+	"tmpDir": "tmp",
+	"logDir": "log"
+}


### PR DESCRIPTION
This is copied to `config/local.json` during the Vagrant provisioning
process (if that file does not exist yet).
